### PR TITLE
fix(scraper): Corrige la importación de Cheerio para compatibilidad c…

### DIFF
--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -1,4 +1,4 @@
-import cheerio from 'cheerio'
+import * as cheerio from 'cheerio'
 import fetch from 'node-fetch'
 import axios from 'axios'
 import { fbdl } from '@mrnima/facebook-downloader';


### PR DESCRIPTION
…on ESM

Se ha actualizado la declaración de importación de `cheerio` en `lib/scraper.js` de `import cheerio from 'cheerio'` a `import * as cheerio from 'cheerio'`.

Este cambio soluciona un error de ejecución (`SyntaxError: The requested module 'cheerio' does not provide an export named 'default'`) que ocurría porque el proyecto utiliza módulos ES (ESM) y `cheerio` es un módulo CommonJS (CJS) que no tiene una exportación por defecto.