### PR TITLE
fix: Corrige las importaciones de módulos CJS y elimina la opción de …

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,7 +228,6 @@ async function connectToWhatsApp() {
     logger,
     
     browser: usingCode ? Browsers.macOS('Safari') : ['GaaraUltraMD', 'Chrome', '1.0.0'],
-    printQRInTerminal: option === '1',
     markOnlineOnConnect: false,
     syncFullHistory: false,
     generateHighQualityLinkPreview: false

--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -1,8 +1,10 @@
 import * as cheerio from 'cheerio'
 import fetch from 'node-fetch'
 import axios from 'axios'
-import { fbdl } from '@mrnima/facebook-downloader';
-import { instagramDownload } from '@mrnima/instagram-downloader';
+import facebookDownloader from '@mrnima/facebook-downloader';
+const { fbdl } = facebookDownloader;
+import instagramDownloader from '@mrnima/instagram-downloader';
+const { instagramDownload } = instagramDownloader;
 
 async function sekaikomikDl(url) {
 	let res = await fetch(url)


### PR DESCRIPTION
…QR obsoleta

Este commit soluciona varios errores de ejecución relacionados con la importación de módulos CommonJS (CJS) en un entorno de módulos ES (ESM).

Cambios:
- Se ha corregido la importación de `@mrnima/facebook-downloader` y `@mrnima/instagram-downloader` en `lib/scraper.js` para utilizar la sintaxis de importación por defecto compatible.
- Se ha eliminado la opción obsoleta `printQRInTerminal` de la configuración de Baileys en `index.js` para eliminar una advertencia de desaprobación.

Estos cambios deberían resolver los fallos de inicio y permitir que la aplicación se ejecute de forma estable.