### PR TITLE
feat(economia): añade cobro de coins a los comandos de artista

### DIFF
--- a/lib/artistDownloader.js
+++ b/lib/artistDownloader.js
@@ -1,5 +1,8 @@
 import yts from 'yt-search';
 import axios from 'axios';
+import { readUsersDb, writeUsersDb } from './database.js';
+
+const COST = 400;
 
 /**
  * Busca y descarga los medios de un artista (audio o video).
@@ -13,6 +16,18 @@ import axios from 'axios';
  * @param {string} params.format - El formato a descargar ('audio' or 'video').
  */
 export async function downloadArtistMedia({ sock, msg, args, commandName, downloadingState, apiConfig, format }) {
+  const senderId = msg.sender;
+  const usersDb = readUsersDb();
+  const user = usersDb[senderId];
+
+  if (!user) {
+    return sock.sendMessage(msg.key.remoteJid, { text: "No estás registrado. Usa el comando `reg` para registrarte." }, { quoted: msg });
+  }
+
+  if ((user.coins || 0) < COST) {
+    return sock.sendMessage(msg.key.remoteJid, { text: `⚠️ No tienes suficientes coins para usar este comando. Necesitas ${COST} coins y solo tienes ${user.coins || 0}.` }, { quoted: msg });
+  }
+
   if (downloadingState.isDownloading) {
     return sock.sendMessage(msg.key.remoteJid, { text: `⚠️ ¡Ya hay una descarga del comando ${commandName} en curso! Por favor, espera a que termine.` }, { quoted: msg });
   }
@@ -21,6 +36,11 @@ export async function downloadArtistMedia({ sock, msg, args, commandName, downlo
   if (!artistName) {
     return sock.sendMessage(msg.key.remoteJid, { text: "💡 Debes proporcionar el nombre de un artista." }, { quoted: msg });
   }
+
+  // Cobrar al usuario
+  user.coins -= COST;
+  writeUsersDb(usersDb);
+  await sock.sendMessage(msg.key.remoteJid, { text: `💸 Se han descontado ${COST} coins por usar el comando *${commandName}*.` }, { quoted: msg });
 
   downloadingState.isDownloading = true;
   let waitingMsg;
@@ -81,7 +101,10 @@ export async function downloadArtistMedia({ sock, msg, args, commandName, downlo
 
   } catch (error) {
     console.error(`Error en el comando ${commandName}:`, error);
-    const errorText = `❌ *Error general en ${commandName}:* ${error.message}`;
+    // Si hay un error, devolver las coins
+    user.coins += COST;
+    writeUsersDb(usersDb);
+    const errorText = `❌ *Error general en ${commandName}:* ${error.message}\n\nSe te han devuelto tus ${COST} coins.`;
     if (waitingMsg) {
       await sock.sendMessage(msg.key.remoteJid, { text: errorText }, { edit: waitingMsg.key });
     } else {


### PR DESCRIPTION
- Se ha implementado un sistema de cobro en los comandos 'artista' y 'artista2'.
- Cada uso de estos comandos ahora descuenta 400 coins del saldo del usuario.
- Se ha añadido una comprobación para asegurar que el usuario tenga saldo suficiente antes de ejecutar el comando.
- En caso de un error grave durante la ejecución que impida la descarga, las coins se devuelven al usuario.