### PR TITLE
fix(facebook): Corrige el envío de doble mensaje de error y éxito

### DIFF
--- a/plugins/facebook.js
+++ b/plugins/facebook.js
@@ -48,7 +48,11 @@ const facebookCommand = {
       );
 
       // Eliminar el mensaje de "Procesando..."
-      await sock.deleteMessage(msg.key.remoteJid, waitingMsg.key);
+      try {
+        await sock.deleteMessage(msg.key.remoteJid, waitingMsg.key);
+      } catch (deleteError) {
+        console.error("Error al eliminar el mensaje de espera:", deleteError);
+      }
 
     } catch (error) {
       console.error("Error en el comando facebook:", error.message);


### PR DESCRIPTION
- Se ha solucionado un error por el que se enviaba el vídeo y un mensaje de error simultáneamente.
- El problema ocurría cuando la eliminación del mensaje de "Procesando..." fallaba después de una descarga exitosa.
- Se ha aislado la lógica de eliminación del mensaje para que sus errores no se propaguen al flujo principal.