### PR TITLE
fix(config): Se ha actualizado la baseURL en la configuración de la A…

### DIFF
--- a/config.js
+++ b/config.js
@@ -22,7 +22,7 @@ const config = {
   // No es necesario modificar estas si usas las APIs públicas de Adonix.
   api: {
     adonix: {
-      baseURL: "https://myapiadonix.casacam.net",
+      baseURL: "https://api-adonix.ultraplus.click",
       apiKey: "AdonixKeyvomkuv5056"
     },
     gemini: "AIzaSyDEww4IKqba9tgfb8ndMDBOoLkl-nSy4tw" // Tu API Key de Gemini


### PR DESCRIPTION
…PI de Adonix al nuevo dominio.

El dominio anterior 'myapiadonix.casacam.net' ha sido reemplazado por 'api-adonix.ultraplus.click'.

Este cambio restaura la funcionalidad de todos los comandos que dependen de esta API.