### PR TITLE
fix(menu): actualiza la imagen del menú del bot

### DIFF
--- a/plugins/menu.js
+++ b/plugins/menu.js
@@ -74,9 +74,9 @@ const menuCommand = {
     await sock.sendMessage(
       msg.key.remoteJid,
       {
-        image: { url: 'https://files.catbox.moe/itgz1x.png' }, // Podríamos cambiar esta imagen también
+        image: { url: 'https://files.catbox.moe/tr0lls.jpg' },
         caption: menuText,
-        mimetype: 'image/png'
+        mimetype: 'image/jpeg'
       },
       { quoted: msg }
     );


### PR DESCRIPTION
- Se ha actualizado la URL de la imagen en el comando del menú.
- La nueva imagen 'https://files.catbox.moe/tr0lls.jpg' se muestra ahora junto con el menú.