### PR TITLE
fix(facebook): Prevent sending error message if video is sent

### DIFF
--- a/plugins/facebook.js
+++ b/plugins/facebook.js
@@ -16,6 +16,7 @@ const facebookCommand = {
     }
 
     const waitingMsg = await sock.sendMessage(msg.key.remoteJid, { text: `🔱 Swimming for your video... 🌊` }, { quoted: msg });
+    let videoSent = false;
 
     try {
       const apiUrl = `${config.api.adonix.baseURL}/download/facebook?apikey=${config.api.adonix.apiKey}&url=${encodeURIComponent(url)}`;
@@ -46,6 +47,7 @@ const facebookCommand = {
         },
         { quoted: msg }
       );
+      videoSent = true;
 
       // Eliminar el mensaje de "Procesando..."
       try {
@@ -56,8 +58,10 @@ const facebookCommand = {
 
     } catch (error) {
       console.error("Error en el comando facebook:", error.message);
-      const errorMessage = "❌ No se pudo descargar el video de Facebook. El servicio puede no estar disponible o el enlace ser inválido. Por favor, inténtalo de nuevo más tarde.";
-      await sock.sendMessage(msg.key.remoteJid, { text: errorMessage, edit: waitingMsg.key });
+      if (!videoSent) {
+        const errorMessage = "❌ No se pudo descargar el video de Facebook. El servicio puede no estar disponible o el enlace ser inválido. Por favor, inténtalo de nuevo más tarde.";
+        await sock.sendMessage(msg.key.remoteJid, { text: errorMessage, edit: waitingMsg.key });
+      }
     }
   }
 };


### PR DESCRIPTION
This commit fixes a bug in the `facebook` command where an error occurring after the video was sent would cause an error message to be sent to the user, resulting in the user receiving both the video and an error message.

A `videoSent` flag is introduced to track the status of the video sending. The error handling logic is updated to only send an error message if the video has not been sent.