### PR TITLE
fix(play): replace with new stable implementation

### DIFF
--- a/plugins/play.js
+++ b/plugins/play.js
@@ -2,13 +2,15 @@ import fetch from "node-fetch";
 import yts from "yt-search";
 import axios from "axios";
 
-// Helper functions and objects are now self-contained within this file.
+// Helper object for the downloader API
 const ddownr = {
   download: async (url, format) => {
     const config = {
-      method: "GET",
+      method: 'GET',
       url: `https://p.oceansaver.in/ajax/download.php?format=${format}&url=${encodeURIComponent(url)}&api=dfcb6d76f2f6a9894gjkege8a4ab232222`,
-      headers: { "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, como Gecko) Chrome/91.0.4472.124 Safari/537.36" }
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, como Gecko) Chrome/91.0.4472.124 Safari/537.36'
+      }
     };
     const response = await axios.request(config);
     if (response.data && response.data.success) {
@@ -16,13 +18,16 @@ const ddownr = {
       const downloadUrl = await ddownr.cekProgress(id);
       return downloadUrl;
     }
-    throw new Error("Fallo al obtener los detalles del video desde la API principal.");
+    throw new Error('Fallo al obtener los detalles del video.');
   },
+
   cekProgress: async (id) => {
     const config = {
-      method: "GET",
+      method: 'GET',
       url: `https://p.oceansaver.in/ajax/progress.php?id=${id}`,
-      headers: { "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, como Gecko) Chrome/91.0.4472.124 Safari/537.36" }
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, como Gecko) Chrome/91.0.4472.124 Safari/537.36'
+      }
     };
     while (true) {
       const response = await axios.request(config);
@@ -34,21 +39,10 @@ const ddownr = {
   }
 };
 
-const apisExtra = [
-  {
-    name: "Vreden",
-    fetchUrl: async (url) => {
-      const res = await fetch(`https://api.vreden.my.id/api/ytmp3?url=${encodeURIComponent(url)}`);
-      const data = await res.json();
-      return data?.result?.download?.url || null;
-    }
-  }
-];
-
 const playCommand = {
   name: "play",
   category: "descargas",
-  description: "Busca y descarga una canción y la envía como audio.",
+  description: "Busca y descarga una canción de YouTube.",
   aliases: ["ytmp3"],
 
   async execute({ sock, msg, args }) {
@@ -58,52 +52,33 @@ const playCommand = {
         return sock.sendMessage(msg.key.remoteJid, { text: "Por favor, ingresa el nombre de una canción para buscar." }, { quoted: msg });
       }
 
-      await sock.sendMessage(msg.key.remoteJid, { react: { text: "🎵", key: msg.key } });
+      await sock.sendMessage(msg.key.remoteJid, { react: { text: "🔎", key: msg.key } });
 
       const search = await yts(text);
       if (!search.all || search.all.length === 0) {
-        return sock.sendMessage(msg.key.remoteJid, { text: "No se encontraron resultados para tu búsqueda." }, { quoted: msg });
+        return sock.sendMessage(msg.key.remoteJid, { text: 'No se encontraron resultados para tu búsqueda.' }, { quoted: msg });
       }
 
       const videoInfo = search.all[0];
       const { title, url } = videoInfo;
 
-      await sock.sendMessage(msg.key.remoteJid, { text: `Buscando y descargando: *${title}*`}, { quoted: msg });
+      await sock.sendMessage(msg.key.remoteJid, { text: `Descargando: *${title}*`}, { quoted: msg });
 
-      let downloadUrl = null;
-      try {
-        downloadUrl = await ddownr.download(url, "mp3");
-      } catch (e) {
-        console.error("API Principal (ddownr) falló:", e.message);
-        console.log("Intentando con APIs de respaldo...");
-        for (let api of apisExtra) {
-          try {
-            downloadUrl = await api.fetchUrl(url);
-            if (downloadUrl) {
-              console.log(`Éxito con la API de respaldo: ${api.name}`);
-              break;
-            }
-          } catch (err) { continue; }
-        }
-      }
+      const downloadUrl = await ddownr.download(url, 'mp3');
 
       if (downloadUrl) {
-        const audioResponse = await axios.get(downloadUrl, { responseType: 'arraybuffer' });
-        const audioBuffer = audioResponse.data;
-
         await sock.sendMessage(
           msg.key.remoteJid,
           {
-            audio: audioBuffer,
-            mimetype: "audio/mpeg",
-            ptt: false
+            audio: { url: downloadUrl },
+            mimetype: 'audio/mpeg'
           },
           { quoted: msg }
         );
         await sock.sendMessage(msg.key.remoteJid, { react: { text: "✅", key: msg.key } });
       } else {
         await sock.sendMessage(msg.key.remoteJid, { react: { text: "❌", key: msg.key } });
-        return sock.sendMessage(msg.key.remoteJid, { text: "No se pudo descargar el audio después de intentar con todas las APIs disponibles." }, { quoted: msg });
+        return sock.sendMessage(msg.key.remoteJid, { text: "No se pudo obtener un enlace de descarga." }, { quoted: msg });
       }
     } catch (error) {
       console.error("Error en el comando play:", error);


### PR DESCRIPTION
This commit replaces the logic of the `play` command with a new version provided by the user to solve download failures.

The new implementation is self-contained and uses a single, direct API endpoint (`p.oceansaver.in`) for downloads. It sends the result as a playable audio message by providing the URL directly to the sender.

This is a hotfix to ensure the `play` command is functional.