### PR TITLE
feat(play): re-implement with new API and UX

### DIFF
--- a/plugins/play.js
+++ b/plugins/play.js
@@ -1,89 +1,99 @@
-import fetch from "node-fetch";
-import yts from "yt-search";
-import axios from "axios";
+import yts from 'yt-search';
+import fetch from 'node-fetch';
+import config from '../config.js'; // Assuming config is not in .cjs
 
-// Helper object for the downloader API
-const ddownr = {
-  download: async (url, format) => {
-    const config = {
-      method: 'GET',
-      url: `https://p.oceansaver.in/ajax/download.php?format=${format}&url=${encodeURIComponent(url)}&api=dfcb6d76f2f6a9894gjkege8a4ab232222`,
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, como Gecko) Chrome/91.0.4472.124 Safari/537.36'
-      }
-    };
-    const response = await axios.request(config);
-    if (response.data && response.data.success) {
-      const { id } = response.data;
-      const downloadUrl = await ddownr.cekProgress(id);
-      return downloadUrl;
-    }
-    throw new Error('Fallo al obtener los detalles del video.');
-  },
-
-  cekProgress: async (id) => {
-    const config = {
-      method: 'GET',
-      url: `https://p.oceansaver.in/ajax/progress.php?id=${id}`,
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, como Gecko) Chrome/91.0.4472.124 Safari/537.36'
-      }
-    };
-    while (true) {
-      const response = await axios.request(config);
-      if (response.data && response.data.success && response.data.progress === 1000) {
-        return response.data.download_url;
-      }
-      await new Promise(resolve => setTimeout(resolve, 5000));
-    }
+// Helper to send reactions
+async function doReact(emoji, msg, sock) {
+  try {
+    await sock.sendMessage(msg.key.remoteJid, {
+      react: { text: emoji, key: msg.key },
+    });
+  } catch (e) {
+    console.error("Reaction error:", e);
   }
-};
+}
 
 const playCommand = {
   name: "play",
   category: "descargas",
   description: "Busca y descarga una canción de YouTube.",
-  aliases: ["ytmp3"],
+  aliases: ["ytsong", "song", "music"],
 
   async execute({ sock, msg, args }) {
-    const text = args.join(' ').trim();
+    await doReact("🎵", msg, sock);
     try {
-      if (!text) {
-        return sock.sendMessage(msg.key.remoteJid, { text: "Por favor, ingresa el nombre de una canción para buscar." }, { quoted: msg });
+      const query = args.join(' ');
+      if (!query) {
+        const replyText = "✨ *GAWR GURA's Music Player* 🎧\n\n" +
+          "Dime el nombre de una canción y la busco por ti~ 🦈💙\n\n" +
+          "📌 Ejemplo:\n" +
+          `• ${config.PREFIX || '.'}play Dandelions\n` +
+          `• ${config.PREFIX || '.'}song Shape of You`;
+        return await sock.sendMessage(msg.key.remoteJid, { text: replyText }, { quoted: msg });
       }
 
-      await sock.sendMessage(msg.key.remoteJid, { react: { text: "🔎", key: msg.key } });
-
-      const search = await yts(text);
-      if (!search.all || search.all.length === 0) {
-        return sock.sendMessage(msg.key.remoteJid, { text: 'No se encontraron resultados para tu búsqueda.' }, { quoted: msg });
+      await doReact("🔍", msg, sock);
+      const search = await yts(query);
+      const video = search.videos[0];
+      if (!video) {
+        const replyText = `❌ No encontré nada para "${query}" 😢\n\n` +
+          "Intenta con otro nombre de canción, senpai~ 🦈";
+        return await sock.sendMessage(msg.key.remoteJid, { text: replyText }, { quoted: msg });
       }
 
-      const videoInfo = search.all[0];
-      const { title, url } = videoInfo;
-
-      await sock.sendMessage(msg.key.remoteJid, { text: `Descargando: *${title}*`}, { quoted: msg });
-
-      const downloadUrl = await ddownr.download(url, 'mp3');
-
-      if (downloadUrl) {
-        await sock.sendMessage(
-          msg.key.remoteJid,
-          {
-            audio: { url: downloadUrl },
-            mimetype: 'audio/mpeg'
-          },
-          { quoted: msg }
-        );
-        await sock.sendMessage(msg.key.remoteJid, { react: { text: "✅", key: msg.key } });
-      } else {
-        await sock.sendMessage(msg.key.remoteJid, { react: { text: "❌", key: msg.key } });
-        return sock.sendMessage(msg.key.remoteJid, { text: "No se pudo obtener un enlace de descarga." }, { quoted: msg });
+      const apiUrl = `https://apis.davidcyriltech.my.id/download/ytmp3?url=${encodeURIComponent(video.url)}`;
+      const apiRes = await fetch(apiUrl);
+      const json = await apiRes.json();
+      if (!json.success || !json.result?.download_url) {
+        throw new Error("No se pudo obtener el link de descarga de la API.");
       }
-    } catch (error) {
-      console.error("Error en el comando play:", error);
-      await sock.sendMessage(msg.key.remoteJid, { react: { text: "❌", key: msg.key } });
-      return sock.sendMessage(msg.key.remoteJid, { text: `Ocurrió un error inesperado: ${error.message}` }, { quoted: msg });
+
+      const infoMsg =
+        `✨ *GAWR GURA encontró tu canción* 🎶\n\n` +
+        `🎵 *Título:* ${video.title}\n` +
+        `👤 *Artista:* ${video.author.name}\n` +
+        `⏱️ *Duración:* ${video.timestamp}\n` +
+        `👁️ *Vistas:* ${video.views.toLocaleString()}\n\n` +
+        "Preparando el audio... ⏳";
+
+      await sock.sendMessage(
+        msg.key.remoteJid,
+        {
+          image: { url: video.thumbnail },
+          caption: infoMsg,
+        },
+        { quoted: msg }
+      );
+
+      // Como audio
+      await sock.sendMessage(
+        msg.key.remoteJid,
+        {
+          audio: { url: json.result.download_url },
+          mimetype: 'audio/mpeg',
+          fileName: `${video.title.replace(/[^\w\s]/gi, '')}.mp3`,
+        },
+        { quoted: msg }
+      );
+
+      // Como documento
+      await sock.sendMessage(
+        msg.key.remoteJid,
+        {
+          document: { url: json.result.download_url },
+          mimetype: 'audio/mpeg',
+          fileName: `${video.title.replace(/[^\w\s]/gi, '')}.mp3`,
+        },
+        { quoted: msg }
+      );
+
+      await doReact("✅", msg, sock);
+    } catch (e) {
+      console.error("Play error:", e);
+      const errorText = "❌ *Oh no!* 🥺\n\n" +
+        `Error: ${e.message || "Fallo en la descarga"}\n\n` +
+        "Intenta con otra canción~ 💙";
+      await sock.sendMessage(msg.key.remoteJid, { text: errorText }, { quoted: msg });
     }
   }
 };


### PR DESCRIPTION
This commit replaces the `play` command in `plugins/play.js` with a new, self-contained implementation as requested by the user.

The new version adapts a multi-command handler provided by the user into a single, focused `play` command.

It features:
- A new download API (`apis.davidcyriltech.my.id`).
- An improved user experience by first sending an image with song details, followed by the playable audio and a document version of the file.
- All logic is self-contained within the plugin file.