### PR TITLE
chore: Forzar actualización desde la rama main

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,11 +1,23 @@
 #!/bin/bash
 
-# --- Script de Inicio ---
-# Este script ahora solo instala dependencias y ejecuta el bot.
-# La auto-actualización ha sido deshabilitada para permitir cambios locales.
+# --- Script de Inicio y Auto-Actualización desde 'main' ---
+# Este script se asegura de que el bot siempre esté ejecutando la última versión
+# del código desde la rama 'main' de GitHub, descartando cualquier cambio local.
 
-echo ">>> [Paso 1/2] Instalando/actualizando dependencias de Node.js..."
+echo ">>> [Paso 1/3] Forzando actualización desde la rama 'main' de GitHub..."
+
+# Descargar los últimos cambios del origen sin intentar fusionar.
+git fetch origin
+
+# Forzar el reseteo de la rama local a la versión exacta de origin/main.
+# Esto descarta cambios locales y previene errores.
+git reset --hard origin/main
+
+# Limpiar cualquier archivo o directorio no rastreado que pueda interferir.
+git clean -df
+
+echo ">>> [Paso 2/3] Instalando/actualizando dependencias de Node.js..."
 npm install --silent
 
-echo ">>> [Paso 2/2] Iniciando el bot..."
+echo ">>> [Paso 3/3] Iniciando el bot..."
 node index.js


### PR DESCRIPTION
Se ha modificado el script `start.sh` para que siempre se actualice desde la rama `main` del repositorio de origen.

- Se han reintroducido los comandos `git fetch`, `git reset --hard`, y `git clean -df`.
- Se ha hardcodeado la rama `main` como el objetivo del `git reset`, eliminando la detección de la rama actual.

Esto asegura que el bot siempre corra la última versión del código de la rama principal, descartando cualquier cambio local que no haya sido subido al repositorio.